### PR TITLE
Remove info message for non-announced AS0 prefixes.

### DIFF
--- a/irrexplorer/api/report.py
+++ b/irrexplorer/api/report.py
@@ -17,10 +17,8 @@ def enrich_prefix_summaries_with_report(prefix_summaries: List[PrefixSummary]):
         # Detect superfluous route objects
         if not s.bgp_origins and s.irr_origins:
             s.info("Route objects exist, but prefix not seen in DFZ")
-
-        if not s.rpki_origins and ["0"]:
-            if not s.bgp_origins and s.rpki_origins:
-                s.info("RPKI ROA exists, but prefix not seen in DFZ")
+        if not s.bgp_origins and s.rpki_origins and s.rpki_origins != {0}:
+            s.info("RPKI ROA exists, but prefix not seen in DFZ")
 
         # Detect route objects in unexpected IRR
         if s.irr_expected_rir and s.irr_routes and not s.irr_routes_expected_rir:

--- a/irrexplorer/api/report.py
+++ b/irrexplorer/api/report.py
@@ -17,8 +17,10 @@ def enrich_prefix_summaries_with_report(prefix_summaries: List[PrefixSummary]):
         # Detect superfluous route objects
         if not s.bgp_origins and s.irr_origins:
             s.info("Route objects exist, but prefix not seen in DFZ")
-        if not s.bgp_origins and s.rpki_origins:
-            s.info("RPKI ROA exists, but prefix not seen in DFZ")
+
+        if not s.rpki_origins and ["0"]:
+            if not s.bgp_origins and s.rpki_origins:
+                s.info("RPKI ROA exists, but prefix not seen in DFZ")
 
         # Detect route objects in unexpected IRR
         if s.irr_expected_rir and s.irr_routes and not s.irr_routes_expected_rir:


### PR DESCRIPTION
Added test for AS0 ROA that will remove info message about ROA in place but not in DFZ for non-announced AS0 prefixes. To my understanding prefixes with AS0 ROAs are not meant to be announced and as such this is expected behaviour.

I'm not a developer so you may want to double check my commit.